### PR TITLE
Fixed timestep

### DIFF
--- a/dynode/simulation.py
+++ b/dynode/simulation.py
@@ -70,7 +70,7 @@ class Simulation:
         return partial(self._events.remove, event)
 
     #pylint: disable=invalid-name, protected-access
-    def simulate(self, t, store_dt, integrator='dopri5', **kwargs) -> int:
+    def simulate(self, t, store_dt, fixed_step=False, integrator='dopri5', **kwargs) -> int:
         """
         Step forward in time, `t` seconds while storing any stored variables and
          checking events every `store_dt` interval.
@@ -105,8 +105,16 @@ class Simulation:
 
         # Setup of solver
         solver = ode(func)
-        solver.set_integrator(integrator, **kwargs)
         solver.set_initial_value(y0, t=self._t)
+        
+        # Setup of integration scheme
+        if fixed_step:
+            kwargs.update({
+                'first_step': store_dt,
+                'rtol': np.inf,
+                'atol': np.inf
+            })
+        solver.set_integrator(integrator, **kwargs)
 
         # Store initial results
         if self._t == 0:

--- a/dynode/simulation.py
+++ b/dynode/simulation.py
@@ -73,7 +73,9 @@ class Simulation:
     def simulate(self, t, store_dt, fixed_step=False, integrator='dopri5', **kwargs) -> int:
         """
         Step forward in time, `t` seconds while storing any stored variables and
-         checking events every `store_dt` interval.
+         checking events every `store_dt` interval. If `fixed_step=True`, `store_dt`
+         is also used as the internal step size of the solver, leaving the user in
+         charge of choosing a reasonable step size for the problem at hand.
         
         Returns the current time of the simulation.
          

--- a/test/simulation_test.py
+++ b/test/simulation_test.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from dynode.simulation import Simulation as Sim
 
-from test_systems import EmptyTestSystem, VanDerPol, ErrorTestSystem
+from test_systems import EmptyTestSystem, VanDerPol, ErrorTestSystem, MockVanDerPol
 
 def test_empty_simulation():
     sim = Sim()
@@ -73,3 +73,13 @@ def test_states_ders_mismatch():
     with pytest.raises(ValueError):
         sim.simulate(10, 0.1)
 
+def test_fixed_step_size():
+    sim = Sim()
+
+    s = MockVanDerPol()
+    s.states.x = 1
+    sim.add_system(s)
+
+    sim.simulate(3, 0.1, fixed_step=True)
+    
+    assert(s.mock.call_count == 3/0.1*7)

--- a/test/test_systems.py
+++ b/test/test_systems.py
@@ -1,6 +1,7 @@
 """
 Collection of simple systems for test purposes
 """
+import mock
 from dynode import SystemInterface
 
 class VanDerPol(SystemInterface):
@@ -61,3 +62,13 @@ class ErrorTestSystem(EmptyTestSystem):
         self.states.y = 0
         self.ders.dx = 0
         self.ders.dy = 0
+        
+class MockVanDerPol(VanDerPol):
+    
+    def __init__(self):
+        super().__init__()
+        self.mock = mock.Mock()
+        
+    def do_step(self, time):
+        self.mock(time)
+        super().do_step(time)


### PR DESCRIPTION
Adding explicit possibility to use a fixed timestep in the integration. This options hands over the control of deciding a reasonable timestep to the end user to avoid numerical instability etc.